### PR TITLE
fix(Feature): rule for specific env is prior than default env

### DIFF
--- a/packages/caslin-feature/src/__tests__/feature.test.ts
+++ b/packages/caslin-feature/src/__tests__/feature.test.ts
@@ -154,6 +154,30 @@ describe('Feature', () => {
       feature.setEnv('test');
       expect(feature.at('foo').can(['read', 'delete'], 'Post')).toBe(false);
     });
+
+    it('should get false if feature is allowed at all env but forbidden at specific env ', function () {
+      const rules = [
+        { actions: ['read'], subject: 'Post', env: 'test', inverted: true },
+        { actions: ['delete'], subject: 'Post', env: 'test', inverted: true },
+        { actions: ['read'], subject: 'Post', env: 'all' },
+        { actions: ['delete'], subject: 'Post', env: 'all' },
+      ];
+
+      const feature = new Feature(rules);
+      expect(feature.at('test').can(['read', 'delete'], 'Post')).toBe(false);
+    });
+
+    it('should get true if feature is forbidden at all env but allowed at specific env ', function () {
+      const rules = [
+        { actions: ['read'], subject: 'Post', env: 'all', inverted: true },
+        { actions: ['delete'], subject: 'Post', env: 'all', inverted: true },
+        { actions: ['read'], subject: 'Post', env: 'test' },
+        { actions: ['delete'], subject: 'Post', env: 'test' },
+      ];
+
+      const feature = new Feature(rules);
+      expect(feature.at('test').can(['read', 'delete'], 'Post')).toBe(true);
+    });
   });
 
   describe('env', () => {


### PR DESCRIPTION
Changes:

1. make private `_can()` return a result object which indicates if explicit forbidden is declared.
2. add corresponding test cases